### PR TITLE
a bit more sassy

### DIFF
--- a/scss/demo.scss
+++ b/scss/demo.scss
@@ -23,22 +23,6 @@ $main-font: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
     transition: all  $time+s ease;
 }
 
-// some generic classes
-.clearfix:before,
-.clearfix:after {
-    content: " ";
-    display: table;
-}
-
-.clearfix:after {
-    clear: both;
-}
-
-.clearfix {
-    *zoom: 1;
-}
-
-
 body {
 	overflow-x: hidden;
 }

--- a/scss/rrssb.scss
+++ b/scss/rrssb.scss
@@ -47,25 +47,29 @@ $rrssb-main-font: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 	-ms-backface-visibility: hidden;
 }
 
+%border-box {
+	-moz-box-sizing:border-box;
+	box-sizing: border-box;
+}
+
 // some generic classes
-.clearfix:before,
-.clearfix:after {
-    content: " ";
-    display: table;
-}
-
-.clearfix:after {
-    clear: both;
-}
-
 .clearfix {
-    *zoom: 1;
+	*zoom: 1;
+
+	&:after {
+		clear: both;
+	}
+
+	&:before,
+	&:after {
+		content: " ";
+		display: table;
+	}
 }
 
 // the meat and potatoes
 .rrssb-buttons {
-	box-sizing: border-box;
-	-moz-box-sizing:border-box;
+	@extend %border-box;
 	font-family: $rrssb-main-font;
 	height: 36px;
 	margin: 0;
@@ -73,8 +77,7 @@ $rrssb-main-font: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 	width: 100%;
 
 	li {
-		box-sizing: border-box;
-		-moz-box-sizing: border-box;
+		@extend %border-box;
 		display: block;
 		float: left;
 		height: 100%;
@@ -84,8 +87,7 @@ $rrssb-main-font: "Helvetica Neue", Helvetica, Arial, sans-serif !default;
 		padding: 0 2.5px;
 
 		a {
-			box-sizing: border-box;
-			-moz-box-sizing:border-box;
+			@extend %border-box;
 			background-color: #ccc;
 			border-radius: $rrssb-border-radius;
 			display: block;


### PR DESCRIPTION
Hey there, saw this while looking through the github trending repositories and found a few small things I thought I could help out with.  Thanks

removed redundant clearfix class from demo, because it is already part of the rrssb css file.

condense clear fix class into nested Sass selector.

@extend out border-box as it was used in multiple selectors, rearrange so unprefixed version is last.
