### PR TITLE
count only visible list items

### DIFF
--- a/js/rrssb.js
+++ b/js/rrssb.js
@@ -29,7 +29,7 @@
 		// loop through each instance of buttons
 		jQuery('.rrssb-buttons').each(function(index) {
 			var self = jQuery(this);
-			var numOfButtons = jQuery('li', self).length;
+			var numOfButtons = jQuery('li:visible', self).length;
 			var initBtnWidth = 100 / numOfButtons;
 
 			// set initial width of buttons


### PR DESCRIPTION
count only visible list items. this helps to set the width of the visible items when hiding some list items based on document width. (for example using twitter bootstrap hidden/visible classes)
