### PR TITLE
PopupCenter event listener attached to all buttons

### DIFF
--- a/js/rrssb.js
+++ b/js/rrssb.js
@@ -333,7 +333,7 @@
 		 * Event listners
 		 */
 
-		$('.rrssb-buttons a.popup').on('click', function(e){
+                $(document).on('click', '.rrssb-buttons a.popup', {}, function popUp(e) {
 			var self = $(this);
 			popupCenter(self.attr('href'), self.find('.rrssb-text').html(), 580, 470);
 			e.preventDefault();


### PR DESCRIPTION
Original code attaches the event listener to buttons which exist at the single instance of `$(document).ready()`. Buttons added later are missing this listener and don't get the PopupCenter.

This change attaches the listener to all buttons, even those which are made in the future.