### PR TITLE
Twitter sharing button issues on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
         </li>
         <li class="rrssb-twitter">
           <!-- Replace href with your Meta and URL information  -->
-          <a href="http://twitter.com/home?status=Ridiculously%20Responsive%20Social%20Sharing%20Buttons%20by%20%40dbox%20and%20%40joshuatuscan%3A%20http%3A%2F%2Fkurtnoble.com%2Flabs%2Frrssb%20%7C%20http%3A%2F%2Fkurtnoble.com%2Flabs%2Frrssb%2Fmedia%2Frrssb-preview.png"
+          <a href="https://twitter.com/intent/tweet?text=Ridiculously%20Responsive%20Social%20Sharing%20Buttons%20by%20%40dbox%20and%20%40joshuatuscan%3A%20http%3A%2F%2Fkurtnoble.com%2Flabs%2Frrssb%20%7C%20http%3A%2F%2Fkurtnoble.com%2Flabs%2Frrssb%2Fmedia%2Frrssb-preview.png"
           class="popup">
             <span class="rrssb-icon">
               <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">


### PR DESCRIPTION
Twitter sharing button will not show up in popup on iOS.
The official url structure seems to fix the bug:
https://dev.twitter.com/web/tweet-button