### PR TITLE
Ensure newWindow actually exists

### DIFF
--- a/js/rrssb.js
+++ b/js/rrssb.js
@@ -309,7 +309,7 @@
 		var newWindow = window.open(url, title, 'scrollbars=yes, width=' + w + ', height=' + h + ', top=' + top + ', left=' + left);
 
 		// Puts focus on the newWindow
-		if (window.focus) {
+		if (newWindow && newWindow.focus) {
 			newWindow.focus();
 		}
 	};


### PR DESCRIPTION
In some cases (like popup blockers, but not necessarily only that) window.open() will return null. In that case, one should not call newWindow.focus() as it will dereference null.