### PR TITLE
Adhere to npm naming requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "RRSSB",
+  "name": "rrssb",
   "version": "1.8.5",
   "author": "Daniel Box <daniel@kurtnoble.com> (http://github.com/kni-labs)",
   "contributors": [


### PR DESCRIPTION
This commit specifically targets the use of capital letters:

>New packages must not have uppercase letters in the name.

See https://docs.npmjs.com/files/package.json#name

It appears this project hasn't been published to npm yet, so I thought it would be a good time to fix this. If I'm mistaken, feel free to close this request!