### PR TITLE
Javascript: fixed settings for email body and pinterest

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ RRSSB is built with [**SASS**](http://sass-lang.com/), so you can easily customi
 - Adding a class of `popup` to the anchor tag for each share button will make the share dialog open in a popup, rather than a new window. (Good for Facebook, Twitter, Google Plus, etc.)
 - Buttons will automatically flow to the size of the ul `rrssb-buttons`. If fixed sized buttons are needed, nest `rrssb-buttons` in a fixed-width container.
 - Each sharing URL requires various parameters that allow you to pass through messaging in the sharing dialog. A useful tool for URI escaping any messaging that needs to pass through the share URL can be found [**here**](http://meyerweb.com/eric/tools/dencoder/).
-- Optionally, all share meta and links can be configured in `rrssb.js`
+- Alternatively, all share metadata and links can be configured [using Javascript](#javascript)
 
 3) Link to javascript files at the bottom of your document before the closing body tag for best results. (jQuery CDN, [**jQuery fallback**](http://css-tricks.com/snippets/jquery/fallback-for-cdn-hosted-jquery/), and `rrssb.min.js`):
 
@@ -59,6 +59,38 @@ RRSSB is built with [**SASS**](http://sass-lang.com/), so you can easily customi
 <script>window.jQuery || document.write('<script src="js/vendor/jquery.1.10.2.min.js"><\/script>')</script>
 <script src="js/rrssb.min.js"></script>
 ```
+
+
+
+<a name="javascript"></a>
+## Configure URL and Share Text with Javascript 
+
+Instead of editing each `href` by hand, you can call this Javascript to set the URLs on each social button automatically.
+
+This is optional. Note, to support users who have disabled Javascript, you still need to edit the `href`s by hand.
+
+Paste the following before the closing body tag, after the scripts you added in the last section:
+
+````
+<script type="text/javascript">
+
+jQuery(document).ready(function ($) {
+
+  $('.rrssb-buttons').rrssb({
+            // required:
+            title: 'This is the email subject and/or tweet text',
+            url: 'http://kurtnoble.com/labs/rrssb/',
+
+            // optional:
+            description: 'Longer description used with some providers',
+            emailBody: 'Usually email body is just the description + url, but you can customize it if you want'
+    });
+});
+  </script>
+````
+
+
+
 
 ## Other install options:
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ RRSSB is built with [**SASS**](http://sass-lang.com/), so you can easily customi
 
 
 <a name="javascript"></a>
-## Configure URL and Share Text with Javascript 
+### Configure URL and Share Text with Javascript 
 
 Instead of editing each `href` by hand, you can call some Javascript to set the URLs on each social button automatically.
 
@@ -86,7 +86,7 @@ jQuery(document).ready(function ($) {
             emailBody: 'Usually email body is just the description + url, but you can customize it if you want'
     });
 });
-  </script>
+</script>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ RRSSB is built with [**SASS**](http://sass-lang.com/), so you can easily customi
 <a name="javascript"></a>
 ## Configure URL and Share Text with Javascript 
 
-Instead of editing each `href` by hand, you can call this Javascript to set the URLs on each social button automatically.
+Instead of editing each `href` by hand, you can call some Javascript to set the URLs on each social button automatically.
 
 This is optional. Note, to support users who have disabled Javascript, you still need to edit the `href`s by hand.
 
 Paste the following before the closing body tag, after the scripts you added in the last section:
 
-````
+```html
 <script type="text/javascript">
 
 jQuery(document).ready(function ($) {
@@ -87,7 +87,7 @@ jQuery(document).ready(function ($) {
     });
 });
   </script>
-````
+```
 
 
 

--- a/js/rrssb.js
+++ b/js/rrssb.js
@@ -41,6 +41,14 @@
 			url: undefined
 		}, options );
 
+		// use some sensible defaults if they didn't specify email settings
+		settings.emailSubject = settings.emailSubject || settings.title;
+		settings.emailBody = settings.emailBody ||
+			(
+				(settings.description ? settings.description : '') +
+				(settings.url ? '\n\n' + settings.url : '')
+			);
+
 		// Return the encoded strings if the settings have been changed.
 		for (var key in settings) {
 			if (settings.hasOwnProperty(key) && settings[key] !== undefined) {
@@ -56,13 +64,13 @@
 			$(this).find('.rrssb-hackernews a').attr('href', 'https://news.ycombinator.com/submitlink?u=' + settings.url + (settings.title !== undefined ? '&text=' + settings.title : ''));
 			$(this).find('.rrssb-reddit a').attr('href', 'http://www.reddit.com/submit?url=' + settings.url + (settings.description !== undefined ? '&text=' + settings.description : '') + (settings.title !== undefined ? '&title=' + settings.title : ''));
 			$(this).find('.rrssb-googleplus a').attr('href', 'https://plus.google.com/share?url=' + (settings.description !== undefined ? settings.description : '') + '%20' + settings.url);
-			$(this).find('.rrssb-pinterest a').attr('href', 'http://pinterest.com/pin/create/button/?url=' + settings.url + ((settings.image !== undefined) ? '&amp;media=' + settings.image : '') + (settings.description !== undefined ? '&amp;description=' + settings.description : ''));
+			$(this).find('.rrssb-pinterest a').attr('href', 'http://pinterest.com/pin/create/button/?url=' + settings.url + ((settings.image !== undefined) ? '&amp;media=' + settings.image : '') + (settings.description !== undefined ? '&description=' + settings.description : ''));
 			$(this).find('.rrssb-pocket a').attr('href', 'https://getpocket.com/save?url=' + settings.url);
 			$(this).find('.rrssb-github a').attr('href', settings.url);
 		}
 
-		if (settings.emailAddress !== undefined) {
-			$(this).find('.rrssb-email a').attr('href', 'mailto:' + settings.emailAddress + '?' + (settings.emailSubject !== undefined ? 'subject=' + settings.emailSubject : '') + (settings.emailBody !== undefined ? '&amp;body=' + settings.emailBody : ''));
+		if (settings.emailAddress !== undefined || settings.emailSubject) {
+			$(this).find('.rrssb-email a').attr('href', 'mailto:' + (settings.emailAddress ? settings.emailAddress : '') + '?' + (settings.emailSubject !== undefined ? 'subject=' + settings.emailSubject : '') + (settings.emailBody !== undefined ? '&body=' + settings.emailBody : ''));
 		}
 
 	};

--- a/js/rrssb.js
+++ b/js/rrssb.js
@@ -131,7 +131,7 @@
 			var self = $(this);
 			//get button width
 			var containerWidth = self.width();
-			var buttonWidth = $('li', self).not('.small').first().width();
+			var buttonWidth = $('li', self).not('.small').eq(0).width();
 
 			// enlarge buttons if they get wide enough
 			if (buttonWidth > 170 && $('li.small', self).length < 1) {
@@ -157,7 +157,7 @@
 			var smallButtons = buttons.filter('.small');
 			var totalBtnSze = 0;
 			var totalTxtSze = 0;
-			var upCandidate = smallButtons.first();
+			var upCandidate = smallButtons.eq(0);
 			var nextBackUp = parseFloat(upCandidate.attr('data-size')) + 55;
 			var smallBtnCount = smallButtons.length;
 
@@ -167,7 +167,7 @@
 
 				if ((btnCalc + nextBackUp) < containerWidth) {
 					self.removeClass('small-format');
-					smallButtons.first().removeClass('small');
+					smallButtons.eq(0).removeClass('small');
 
 					sizeSmallBtns();
 				}
@@ -341,11 +341,15 @@
 		 * Event listners
 		 */
 
-                $(document).on('click', '.rrssb-buttons a.popup', {}, function popUp(e) {
-			var self = $(this);
-			popupCenter(self.attr('href'), self.find('.rrssb-text').html(), 580, 470);
-			e.preventDefault();
-		});
+		try {
+			$(document).on('click', '.rrssb-buttons a.popup', {}, function popUp(e) {
+				var self = $(this);
+				popupCenter(self.attr('href'), self.find('.rrssb-text').html(), 580, 470);
+				e.preventDefault();
+			});
+		}
+		catch (e) { // catching this adds partial support for jQuery 1.3
+		}
 
 		// resize function
 		$(window).resize(function () {


### PR DESCRIPTION
Fixed some bugs where email body wasn't working when using Javascript to set the title/url etc. Added instructions.

Added backwards-compatible support for jQuery 1.3. 